### PR TITLE
Update package bucket url

### DIFF
--- a/.github/workflows/build-packages.yaml
+++ b/.github/workflows/build-packages.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.12.3
 
       - name: Install dependencies
         env:

--- a/packages/script.py
+++ b/packages/script.py
@@ -20,7 +20,7 @@ def normalize(name):
 # prerequisite: emsdk, pyodide, packages -> pyodide/packages
 
 def gen_bzl_config(tag, dist):
-    bucket_url = "https://pyodide.runtime-playground.workers.dev/python-package-bucket/" + tag + "/"
+    bucket_url = "https://pyodide.edgeworker.net/python-package-bucket/" + tag + "/"
     github_url = "https://github.com/cloudflare/pyodide-build-scripts/releases/download/" + tag + "/"
     lock_bytes = (dist / "pyodide-lock.json").read_bytes()
     lock_hash = hashlib.sha256(lock_bytes).hexdigest()

--- a/packages/script.py
+++ b/packages/script.py
@@ -20,7 +20,7 @@ def normalize(name):
 # prerequisite: emsdk, pyodide, packages -> pyodide/packages
 
 def gen_bzl_config(tag, dist):
-    bucket_url = "https://pub-45d734c4145d4285b343833ee450ef38.r2.dev/" + tag + "/"
+    bucket_url = "https://pyodide.runtime-playground.workers.dev/python-package-bucket/" + tag + "/"
     github_url = "https://github.com/cloudflare/pyodide-build-scripts/releases/download/" + tag + "/"
     lock_bytes = (dist / "pyodide-lock.json").read_bytes()
     lock_hash = hashlib.sha256(lock_bytes).hexdigest()


### PR DESCRIPTION
Switches package bucket url in bazel config file to use our proxy worker. This will have to change again later when we productionize the proxy worker, this PR is just here to test the mirroring functionality. 