### PR TITLE
Change the R2 bucket for python packages

### DIFF
--- a/.github/workflows/r2-bucket-copy.yml
+++ b/.github/workflows/r2-bucket-copy.yml
@@ -1,0 +1,33 @@
+name: Copy R2 bucket contents
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (list objects without copying)"
+        type: boolean
+        default: true
+
+jobs:
+  copy:
+    name: Copy python-package-bucket → pyodide-capnp-bin/python-package-bucket
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install boto3
+      
+      - run: >
+          python packages/copy_r2_bucket.py
+          --src python-package-bucket
+          --dest pyodide-capnp-bin
+          --prefix python-package-bucket
+          ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/r2-bucket-copy.yml
+++ b/.github/workflows/r2-bucket-copy.yml
@@ -1,4 +1,6 @@
 name: Copy R2 bucket contents
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
@@ -7,7 +9,6 @@ on:
         description: "Dry run (list objects without copying)"
         type: boolean
         default: true
-
 jobs:
   copy:
     name: Copy python-package-bucket → pyodide-capnp-bin/python-package-bucket

--- a/packages/copy_r2_bucket.py
+++ b/packages/copy_r2_bucket.py
@@ -1,0 +1,129 @@
+"""
+Copy all objects from one R2 bucket into a subdirectory of another.
+
+Usage:
+    python copy_r2_bucket.py --src SOURCE --dest DEST --prefix PREFIX
+
+Requires environment variables:
+    R2_ACCOUNT_ID
+    R2_ACCESS_KEY_ID
+    R2_SECRET_ACCESS_KEY
+"""
+
+import argparse
+import os
+
+import boto3
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Copy all objects between R2 buckets")
+    parser.add_argument("--src", required=True, help="Source bucket name")
+    parser.add_argument("--dest", required=True, help="Destination bucket name")
+    parser.add_argument(
+        "--prefix", required=True, help="Destination key prefix (subdirectory)"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List what would be copied without copying",
+    )
+    return parser.parse_args()
+
+
+def get_s3_client():
+    r2_account_id = os.environ["R2_ACCOUNT_ID"]
+    r2_access_key = os.environ["R2_ACCESS_KEY_ID"]
+    r2_secret_access_key = os.environ["R2_SECRET_ACCESS_KEY"]
+    return boto3.client(
+        "s3",
+        endpoint_url=f"https://{r2_account_id}.r2.cloudflarestorage.com",
+        aws_access_key_id=r2_access_key,
+        aws_secret_access_key=r2_secret_access_key,
+        region_name="auto",
+    )
+
+
+def list_all_objects(s3, bucket: str) -> list[dict]:
+    objects = []
+    continuation_token = None
+
+    while True:
+        kwargs = {"Bucket": bucket}
+        if continuation_token:
+            kwargs["ContinuationToken"] = continuation_token
+
+        response = s3.list_objects_v2(**kwargs)
+
+        if "Contents" not in response:
+            break
+
+        objects.extend(response["Contents"])
+
+        if response.get("IsTruncated"):
+            continuation_token = response["NextContinuationToken"]
+        else:
+            break
+
+    return objects
+
+
+def copy_objects(
+    s3,
+    src_bucket: str,
+    dest_bucket: str,
+    prefix: str,
+    objects: list[dict],
+    *,
+    dry_run: bool = False,
+) -> None:
+    total = len(objects)
+    failed = []
+
+    for i, obj in enumerate(objects, 1):
+        src_key = obj["Key"]
+        dest_key = prefix + src_key
+
+        if dry_run:
+            print(f"[{i}/{total}] Would copy {src_key} -> {dest_key}")
+            continue
+
+        print(f"[{i}/{total}] Copying {src_key} -> {dest_key}")
+
+        try:
+            s3.copy_object(
+                Bucket=dest_bucket,
+                Key=dest_key,
+                CopySource={"Bucket": src_bucket, "Key": src_key},
+            )
+        except Exception as e:
+            print(f"  FAILED: {e}")
+            failed.append(src_key)
+
+    if failed:
+        raise Exception(f"Failed to copy {len(failed)} objects: {failed}")
+
+
+def main():
+    args = parse_args()
+    prefix = args.prefix if args.prefix.endswith("/") else args.prefix + "/"
+
+    s3 = get_s3_client()
+
+    print(f"Listing objects in {args.src}...")
+    objects = list_all_objects(s3, args.src)
+    print(f"Found {len(objects)} objects.")
+
+    if not objects:
+        print("Nothing to copy.")
+        return
+
+    if args.dry_run:
+        print("DRY RUN — no objects will be copied.")
+
+    copy_objects(s3, args.src, args.dest, prefix, objects, dry_run=args.dry_run)
+    print("Done." if not args.dry_run else "Dry run complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/script.py
+++ b/packages/script.py
@@ -131,7 +131,7 @@ def upload_to_r2(tag: str, dist=Path("dist")) -> None:
     for i in range(ATTEMPTS):
         for path, key in files_remaining:
             print(f"uploading {path} to {key}")
-            s3.upload_file(str(path), "python-package-bucket", key)
+            s3.upload_file(str(path), "pyodide-capnp-bin", f"python-package-bucket/{key}")
 
         new_files_remaining = []
 
@@ -139,7 +139,7 @@ def upload_to_r2(tag: str, dist=Path("dist")) -> None:
 
         for path, key in files_remaining:
             # Construct URL to fetch the uploaded file
-            url = f"https://pyodide.edgeworker.net/python-package-bucket/{key}"
+            url = f"https://pyodide-capnp-bin.edgeworker.net/python-package-bucket/{key}"
             print(f"Checking {url}")
 
             try:


### PR DESCRIPTION
- Change the bucket we store the python packages (`python-package-bucket` => `pyodide-capnp-bin/python-package-bucket`.
- Adds a script that we can run to migrate all the existing files in the old bucket to the new bucket. This script is meant to be idempotent.

After this PR is merged, I will trigger the migration script in CI to migrate all the objects.