### PR TITLE
Update R2 copy script to support cross-bucket copy

### DIFF
--- a/.github/workflows/r2-bucket-copy.yml
+++ b/.github/workflows/r2-bucket-copy.yml
@@ -5,13 +5,41 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Copy mode"
+        type: choice
+        options:
+          - same-account
+          - cross-account
+        default: same-account
+      src_bucket:
+        description: "Source bucket name"
+        required: true
+        default: python-package-bucket
+      dest_bucket:
+        description: "Destination bucket name"
+        required: true
+        default: pyodide-capnp-bin
+      prefix:
+        description: "Destination key prefix (subdirectory)"
+        required: true
+        default: python-package-bucket
+      src_prefix:
+        description: "Only copy objects matching this source key prefix (leave empty for all)"
+        required: false
+        default: ""
+      start_after:
+        description: "Resume after this key (leave empty to start from beginning)"
+        required: false
+        default: ""
       dry_run:
         description: "Dry run (list objects without copying)"
         type: boolean
         default: true
+
 jobs:
   copy:
-    name: Copy python-package-bucket → pyodide-capnp-bin/python-package-bucket
+    name: "Copy ${{ inputs.src_bucket }} → ${{ inputs.dest_bucket }}/${{ inputs.prefix }} (${{ inputs.mode }})"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,14 +49,21 @@ jobs:
           python-version: "3.12"
 
       - run: pip install boto3
-      
+
       - run: >
           python packages/copy_r2_bucket.py
-          --src python-package-bucket
-          --dest pyodide-capnp-bin
-          --prefix python-package-bucket
+          --src '${{ inputs.src_bucket }}'
+          --dest '${{ inputs.dest_bucket }}'
+          --prefix '${{ inputs.prefix }}'
+          ${{ inputs.src_prefix && format('--src-prefix ''{0}''', inputs.src_prefix) || '' }}
+          ${{ inputs.start_after && format('--start-after ''{0}''', inputs.start_after) || '' }}
           ${{ inputs.dry_run && '--dry-run' || '' }}
         env:
+          # Destination account credentials (always required)
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # Source account credentials (only used in cross-account mode)
+          R2_SRC_ACCOUNT_ID: ${{ inputs.mode == 'cross-account' && secrets.R2_SRC_ACCOUNT_ID || '' }}
+          R2_SRC_ACCESS_KEY_ID: ${{ inputs.mode == 'cross-account' && secrets.R2_SRC_ACCESS_KEY_ID || '' }}
+          R2_SRC_SECRET_ACCESS_KEY: ${{ inputs.mode == 'cross-account' && secrets.R2_SRC_SECRET_ACCESS_KEY || '' }}

--- a/packages/copy_r2_bucket.py
+++ b/packages/copy_r2_bucket.py
@@ -1,13 +1,24 @@
 """
 Copy all objects from one R2 bucket into a subdirectory of another.
 
-Usage:
+Supports both same-account and cross-account copies.
+
+Same-account usage (server-side copy):
+    python copy_r2_bucket.py --src SOURCE --dest DEST --prefix PREFIX
+
+Cross-account usage (streams through runner):
     python copy_r2_bucket.py --src SOURCE --dest DEST --prefix PREFIX
 
 Requires environment variables:
+    # Destination (or shared) credentials
     R2_ACCOUNT_ID
     R2_ACCESS_KEY_ID
     R2_SECRET_ACCESS_KEY
+
+    # Source credentials (optional — enables cross-account mode)
+    R2_SRC_ACCOUNT_ID
+    R2_SRC_ACCESS_KEY_ID
+    R2_SRC_SECRET_ACCESS_KEY
 """
 
 import argparse
@@ -24,35 +35,67 @@ def parse_args():
         "--prefix", required=True, help="Destination key prefix (subdirectory)"
     )
     parser.add_argument(
+        "--src-prefix",
+        default="",
+        help="Only copy objects matching this source key prefix",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="List what would be copied without copying",
     )
+    parser.add_argument(
+        "--start-after",
+        default="",
+        help="Resume listing after this key (for resuming interrupted runs)",
+    )
     return parser.parse_args()
 
 
-def get_s3_client():
-    r2_account_id = os.environ["R2_ACCOUNT_ID"]
-    r2_access_key = os.environ["R2_ACCESS_KEY_ID"]
-    r2_secret_access_key = os.environ["R2_SECRET_ACCESS_KEY"]
+def make_s3_client(account_id: str, access_key: str, secret_key: str):
     return boto3.client(
         "s3",
-        endpoint_url=f"https://{r2_account_id}.r2.cloudflarestorage.com",
-        aws_access_key_id=r2_access_key,
-        aws_secret_access_key=r2_secret_access_key,
+        endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
         region_name="auto",
     )
 
 
-def list_all_objects(s3, bucket: str) -> list[dict]:
+def get_s3_clients() -> tuple:
+    """Return (src_s3, dest_s3, is_cross_account).
+
+    If R2_SRC_* env vars are set, creates separate clients for source and
+    destination (cross-account mode). Otherwise, returns the same client
+    for both (same-account mode).
+    """
+    dest_account_id = os.environ["R2_ACCOUNT_ID"]
+    dest_access_key = os.environ["R2_ACCESS_KEY_ID"]
+    dest_secret_key = os.environ["R2_SECRET_ACCESS_KEY"]
+    dest_s3 = make_s3_client(dest_account_id, dest_access_key, dest_secret_key)
+
+    src_account_id = os.environ.get("R2_SRC_ACCOUNT_ID")
+    src_access_key = os.environ.get("R2_SRC_ACCESS_KEY_ID")
+    src_secret_key = os.environ.get("R2_SRC_SECRET_ACCESS_KEY")
+
+    if src_account_id and src_access_key and src_secret_key:
+        src_s3 = make_s3_client(src_account_id, src_access_key, src_secret_key)
+        return src_s3, dest_s3, True
+
+    return dest_s3, dest_s3, False
+
+
+def list_all_objects(
+    s3, bucket: str, start_after: str = "", src_prefix: str = ""
+) -> list[dict]:
     objects = []
-    continuation_token = None
+    kwargs: dict = {"Bucket": bucket}
+    if src_prefix:
+        kwargs["Prefix"] = src_prefix
+    if start_after:
+        kwargs["StartAfter"] = start_after
 
     while True:
-        kwargs = {"Bucket": bucket}
-        if continuation_token:
-            kwargs["ContinuationToken"] = continuation_token
-
         response = s3.list_objects_v2(**kwargs)
 
         if "Contents" not in response:
@@ -61,14 +104,14 @@ def list_all_objects(s3, bucket: str) -> list[dict]:
         objects.extend(response["Contents"])
 
         if response.get("IsTruncated"):
-            continuation_token = response["NextContinuationToken"]
+            kwargs["ContinuationToken"] = response["NextContinuationToken"]
         else:
             break
 
     return objects
 
 
-def copy_objects(
+def copy_objects_same_account(
     s3,
     src_bucket: str,
     dest_bucket: str,
@@ -77,6 +120,7 @@ def copy_objects(
     *,
     dry_run: bool = False,
 ) -> None:
+    """Server-side copy within the same account (original behavior)."""
     total = len(objects)
     failed = []
 
@@ -104,15 +148,68 @@ def copy_objects(
         raise Exception(f"Failed to copy {len(failed)} objects: {failed}")
 
 
+def copy_objects_cross_account(
+    src_s3,
+    dest_s3,
+    src_bucket: str,
+    dest_bucket: str,
+    prefix: str,
+    objects: list[dict],
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Download from source account, upload to destination account."""
+    total = len(objects)
+    failed = []
+
+    for i, obj in enumerate(objects, 1):
+        src_key = obj["Key"]
+        dest_key = prefix + src_key
+
+        if dry_run:
+            print(f"[{i}/{total}] Would transfer {src_key} -> {dest_key}")
+            continue
+
+        size_mb = obj.get("Size", 0) / (1024 * 1024)
+        print(f"[{i}/{total}] Transferring {src_key} -> {dest_key} ({size_mb:.1f} MB)")
+
+        try:
+            response = src_s3.get_object(Bucket=src_bucket, Key=src_key)
+            dest_s3.upload_fileobj(
+                response["Body"],
+                dest_bucket,
+                dest_key,
+                ExtraArgs={
+                    "ContentType": response.get(
+                        "ContentType", "application/octet-stream"
+                    ),
+                },
+            )
+        except Exception as e:
+            print(f"  FAILED: {e}")
+            failed.append(src_key)
+
+    if failed:
+        raise Exception(f"Failed to transfer {len(failed)} objects: {failed}")
+
+
 def main():
     args = parse_args()
     prefix = args.prefix if args.prefix.endswith("/") else args.prefix + "/"
 
-    s3 = get_s3_client()
+    src_s3, dest_s3, is_cross_account = get_s3_clients()
+    mode = "cross-account" if is_cross_account else "same-account"
+    print(f"Mode: {mode}")
 
-    print(f"Listing objects in {args.src}...")
-    objects = list_all_objects(s3, args.src)
+    src_label = f"{args.src}/{args.src_prefix}*" if args.src_prefix else args.src
+    print(f"Listing objects in {src_label}...")
+    objects = list_all_objects(
+        src_s3, args.src, start_after=args.start_after, src_prefix=args.src_prefix
+    )
     print(f"Found {len(objects)} objects.")
+
+    if args.start_after:
+        print(f"(Resuming after key: {args.start_after})")
 
     if not objects:
         print("Nothing to copy.")
@@ -121,7 +218,15 @@ def main():
     if args.dry_run:
         print("DRY RUN — no objects will be copied.")
 
-    copy_objects(s3, args.src, args.dest, prefix, objects, dry_run=args.dry_run)
+    if is_cross_account:
+        copy_objects_cross_account(
+            src_s3, dest_s3, args.src, args.dest, prefix, objects, dry_run=args.dry_run
+        )
+    else:
+        copy_objects_same_account(
+            src_s3, args.src, args.dest, prefix, objects, dry_run=args.dry_run
+        )
+
     print("Done." if not args.dry_run else "Dry run complete.")
 
 


### PR DESCRIPTION
I migrated all the python packages files in our prod bucket using #13, but I noticed that we are storing python packages for the [package version 20240829.4 in our playground account](https://github.com/cloudflare/workerd/blob/a9ed77fefba3cc905efc24c048b73e4d19ff3027/src/pyodide/internal/metadata.ts#L32-L40),  not in the prod bucket. They also needs migration.

To migrate those files as well, this PR updates the migration script to support cross-bucket copy.

__Test Plan__

Tested locally with my personal account:

```sh
python packages/copy_r2_bucket.py --src python-package-bucket --dest pyodide-capnp-bin --prefix python-package-bucket --src-prefix "20240829.4"
```